### PR TITLE
Fix illegal pattern in a function pointer type

### DIFF
--- a/src/parser/nodes.rs
+++ b/src/parser/nodes.rs
@@ -119,7 +119,7 @@ pub struct CommandNode {
     /// [`TreeNode`]: struct.TreeNode.html
     pub node: TreeNode,
     /// The handler which is executed once this node has been accepted.
-    pub handler: Option<fn(&node: Node) -> ()>,
+    pub handler: Option<fn(node: &Node) -> ()>,
     /// Parameter nodes for this command
     pub parameters: Vec<Rc<Node>>,
     /// If present, the command wrapped by this node.
@@ -267,7 +267,7 @@ impl CommandNode {
                hidden: bool,
                priority: i32,
                successors: Vec<Rc<Node>>,
-               handler: Option<fn(&node: Node) -> ()>,
+               handler: Option<fn(node: &Node) -> ()>,
                parameters: Vec<Rc<Node>>)
                -> Self {
         CommandNode {


### PR DESCRIPTION
This crate was broken by a recent bugfix in `rustc` (see https://github.com/rust-lang/rust/pull/35015).
Here's a fix.
